### PR TITLE
Update to examples and azurecaf provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.0 (March 2020)
+
+IMPROVEMENTS:
+
+* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#8](https://github.com/aztfmod/terraform-azurerm-caf-container-registry/issues/8))
+
+
 ## v1.0 (January 2020)
 
 FEATURES: 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ module "acr" {
 | diagnostics_settings | object | None | (Required) Map with the diagnostics settings for ASR deployment. See the required structure in the following example or in the diagnostics module documentation. | 
 | admin_enabled | bool | False | (Optional) Specifies whether the admin user is enabled. | 
 | sku | string | Basic | (Optional) The SKU name of the the container registry. Possible values are Basic, Standard and Premium. Default = Basic.  | 
-| georeplication_locations | list | null | A list of Azure locations where the container registry should be geo-replicated (only valid if SKU is premium) | 
-| convention | string | None | Naming convention to be used (check at the naming convention module for possible values).  | 
+| georeplication_locations | list | null | (Optional) A list of Azure locations where the container registry should be geo-replicated (only valid if SKU is premium) | 
+| convention | string | None | (Required) Naming convention to be used (check at the naming convention module for possible values).  | 
 | prefix | string | None | (Optional) Prefix to be used. |
 | postfix | string | None | (Optional) Postfix to be used. |
 | max_length | string | None | (Optional) maximum length to the name of the resource. |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitter](https://badges.gitter.im/aztfmod/community.svg)](https://gitter.im/aztfmod/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
 # Deploys an Azure Container Registry
 Creates an Azure Container Registry in a given region 
 
@@ -7,7 +9,7 @@ module "acr" {
     source  = "aztfmod/caf-container-registry/azurerm"
     version = "0.x.y"
     
-    rg                                = var.rg
+    resource_group_name               = var.resource_group_name
     name                              = var.name
     location                          = var.location
     tags                              = var.tags
@@ -20,18 +22,20 @@ module "acr" {
 
 | Name | Type | Default | Description | 
 | -- | -- | -- | -- | 
-| name | string | None | Specifies the name of the Container Registry. Changing this forces a new resource to be created. |
-| rg | string | None | The name of the resource group in which to create the Container Registry. Changing this forces a new resource to be created. |
-| location | string | None | Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.  | 
-| tags | map | None | Map of tags for the deployment.  | 
-| la_workspace_id | string | None | Log Analytics Repository ID. | 
-| diagnostics_map | map | None | Map with the diagnostics repository information.  | 
-| diagnostics_settings | object | None | Map with the diagnostics settings for ASR deployment. See the required structure in the following example or in the diagnostics module documentation. | 
-| admin_enabled | bool | False | Specifies whether the admin user is enabled.  | 
-| sku | string | Basic | The SKU name of the the container registry. Possible values are Basic, Standard and Premium. Default = Basic.  | 
-| georeplication_locations | list | null | A list of Azure locations where the container registry should be geo-replicated (only valid if SKU is premium)  | 
+| name | string | None | (Required) Specifies the name of the Container Registry. Changing this forces a new resource to be created. |
+| resource_group_name | string | None | (Required) The name of the resource group in which to create the Container Registry. Changing this forces a new resource to be created. |
+| location | string | None | (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.  | 
+| tags | map | None | (Required) Map of tags for the deployment.  | 
+| la_workspace_id | string | None | (Required) Log Analytics Repository ID. | 
+| diagnostics_map | map | None | (Required) Map with the diagnostics repository information.  | 
+| diagnostics_settings | object | None | (Required) Map with the diagnostics settings for ASR deployment. See the required structure in the following example or in the diagnostics module documentation. | 
+| admin_enabled | bool | False | (Optional) Specifies whether the admin user is enabled. | 
+| sku | string | Basic | (Optional) The SKU name of the the container registry. Possible values are Basic, Standard and Premium. Default = Basic.  | 
+| georeplication_locations | list | null | A list of Azure locations where the container registry should be geo-replicated (only valid if SKU is premium) | 
 | convention | string | None | Naming convention to be used (check at the naming convention module for possible values).  | 
-| prefix | string | None | Prefix to be used (to be deprecated)  | 
+| prefix | string | None | (Optional) Prefix to be used. |
+| postfix | string | None | (Optional) Postfix to be used. |
+| max_length | string | None | (Optional) maximum length to the name of the resource. |
 
 
 ## Output

--- a/examples/acr_premium/acr.tf
+++ b/examples/acr_premium/acr.tf
@@ -10,7 +10,7 @@ resource "azurerm_resource_group" "rg_test" {
 
 module "la_test" {
   source  = "aztfmod/caf-log-analytics/azurerm"
-  version = "2.0.0"
+  version = "2.0.1"
   
     convention          = local.convention
     location            = local.location
@@ -23,7 +23,7 @@ module "la_test" {
 
 module "diags_test" {
   source  = "aztfmod/caf-diagnostics-logging/azurerm"
-  version = "2.0.0"
+  version = "2.0.1"
 
   convention            = local.convention
   name                  = local.name

--- a/examples/acr_premium/acr.tf
+++ b/examples/acr_premium/acr.tf
@@ -1,32 +1,33 @@
-module "rg_test" {
-  source  = "aztfmod/caf-resource-group/azurerm"
-  version = "0.1.1"
-  
-    prefix          = local.prefix
-    resource_groups = local.resource_groups
-    tags            = local.tags
+provider "azurerm" {
+   features {}
+}
+
+resource "azurerm_resource_group" "rg_test" {
+  name     = local.resource_groups.test.name
+  location = local.resource_groups.test.location
+  tags     = local.tags
 }
 
 module "la_test" {
   source  = "aztfmod/caf-log-analytics/azurerm"
-  version = "1.0.0"
+  version = "2.0.0"
   
     convention          = local.convention
     location            = local.location
     name                = local.name
     solution_plan_map   = local.solution_plan_map 
     prefix              = local.prefix
-    resource_group_name = module.rg_test.names.test
+    resource_group_name = azurerm_resource_group.rg_test.name
     tags                = local.tags
 }
 
 module "diags_test" {
   source  = "aztfmod/caf-diagnostics-logging/azurerm"
-  version = "1.0.0"
+  version = "2.0.0"
 
   convention            = local.convention
   name                  = local.name
-  resource_group_name   = module.rg_test.names.test
+  resource_group_name   = azurerm_resource_group.rg_test.name
   prefix                = local.prefix
   location              = local.location
   tags                  = local.tags
@@ -39,7 +40,7 @@ module "acr_test" {
   prefix                      = local.prefix
   convention                  = local.convention
   name                        = local.name
-  rg                          = module.rg_test.names.test
+  resource_group_name         = azurerm_resource_group.rg_test.name
   location                    = local.location 
   tags                        = local.tags
   la_workspace_id             = module.la_test.id

--- a/examples/acr_premium/locals.tf
+++ b/examples/acr_premium/locals.tf
@@ -1,11 +1,11 @@
 locals {
-    convention = "random"
+    convention = "cafclassic"
     name = "caftestacrdeploy"
     location = "southeastasia"
     prefix = ""
     resource_groups = {
         test = { 
-            name     = "test-caf"
+            name     = "test-caf-acr"
             location = "southeastasia" 
         },
     }

--- a/module.tf
+++ b/module.tf
@@ -1,15 +1,15 @@
-module "caf_name_acr" {
-  source  = "aztfmod/caf-naming/azurerm"
-  version = "~> 0.1.0"
-
-  name    = var.name
-  type    = "acr"
-  convention  = var.convention
+resource "azurecaf_naming_convention" "caf_name_acr" {  
+  name          = var.name
+  prefix        = var.prefix != "" ? var.prefix : null
+  postfix       = var.postfix != "" ? var.postfix : null
+  max_length    = var.max_length != "" ? var.max_length : null
+  resource_type = "acr"
+  convention    = var.convention
 }
 
 resource "azurerm_container_registry" "acr" {
-  name                      = module.caf_name_acr.acr
-  resource_group_name       = var.rg
+  name                      = azurecaf_naming_convention.caf_name_acr.result
+  resource_group_name       = var.resource_group_name
   location                  = var.location
   sku                       = var.sku
   admin_enabled             = var.admin_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,8 @@
-variable "prefix" {
-
-}
-
 variable "name" {
     description = "(Required) Specifies the name of the Container Registry. Changing this forces a new resource to be created."
 }
 
-variable "rg" {
+variable "resource_group_name" {
     description = "(Required) The name of the resource group in which to create the Container Registry. Changing this forces a new resource to be created."
 }
 
@@ -48,4 +44,22 @@ variable "diagnostics_map" {
 
 variable "la_workspace_id" {
   description = "(Required) Log analytics repository ID"
+}
+
+variable "prefix" {
+  description = "(Optional) You can use a prefix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "postfix" {
+  description = "(Optional) You can use a postfix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "max_length" {
+  description = "(Optional) You can speficy a maximum length to the name of the resource"
+  type        = string
+  default = ""
 }


### PR DESCRIPTION
## v2.0 (March 2020)

IMPROVEMENTS:

* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#8](https://github.com/aztfmod/terraform-azurerm-caf-container-registry/issues/8))
